### PR TITLE
Add default value for initial rating

### DIFF
--- a/lib/rating_dialog.dart
+++ b/lib/rating_dialog.dart
@@ -156,19 +156,20 @@ class RatingDialog extends StatefulWidget {
 
   final VoidCallback onAlternativePressed;
 
-  RatingDialog(
-      {@required this.icon,
-      @required this.title,
-      @required this.description,
-      @required this.onSubmitPressed,
-      @required this.submitButton,
-      this.initialRating,
-      this.accentColor = Colors.blue,
-      this.alternativeButton = "",
-      this.positiveComment = "",
-      this.negativeComment = "",
-      this.onAlternativePressed,
-      this.onCommentPressed});
+  RatingDialog({
+    @required this.icon,
+    @required this.title,
+    @required this.description,
+    @required this.onSubmitPressed,
+    @required this.submitButton,
+    this.initialRating = 0,
+    this.accentColor = Colors.blue,
+    this.alternativeButton = "",
+    this.positiveComment = "",
+    this.negativeComment = "",
+    this.onAlternativePressed,
+    this.onCommentPressed,
+  });
 
   @override
   _RatingDialogState createState() => new _RatingDialogState();


### PR DESCRIPTION
If no initial rating is passed the plugin throws an exception, because the rating (which is null) gets compared with an integer.